### PR TITLE
correctly get inactive stake amount for withdraw and fix little issues

### DIFF
--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -29,6 +29,7 @@ use solana_sdk::{
     fee_calculator::DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE,
     instruction::Instruction,
     signer::{keypair::Keypair, Signer},
+    stake::state::StakeState,
 };
 use solana_vote_program::vote_state::VoteState;
 use solido_cli_common::{
@@ -971,19 +972,15 @@ impl SolidoState {
             self.validator_stake_accounts.iter(),
             self.validator_unstake_accounts.iter()
         ) {
-            let current_stake_balance = stake_accounts
+            let stake_rent = Lamports(self.rent.minimum_balance(std::mem::size_of::<StakeState>()));
+            let expected_difference_stake = stake_accounts
                 .iter()
-                .map(|(_addr, detail)| detail.balance.total())
+                .map(|(_addr, detail)| {
+                    (detail.balance.inactive - stake_rent)
+                        .expect("Inactive stake is always greater then rent exempt amount")
+                })
                 .sum::<lido::token::Result<Lamports>>()
                 .expect("If this overflows, there would be more than u64::MAX staked.");
-
-            let expected_difference_stake =
-                if current_stake_balance > validator.entry.effective_stake_balance() {
-                    (current_stake_balance - validator.entry.effective_stake_balance())
-                        .expect("Does not overflow because current > entry.balance.")
-                } else {
-                    Lamports(0)
-                };
 
             let mut removed_unstake = Lamports(0);
 
@@ -1117,7 +1114,7 @@ impl SolidoState {
             SolidoState::UNBALANCE_THRESHOLD,
         )?;
         let validator = &self.solido.validators.entries[validator_index];
-        let stake_account = &self.validator_stake_accounts[validator_index][0];
+        let stake_account = &self.validator_stake_accounts[validator_index].get(0)?;
 
         let maximum_unstake = (stake_account.1.balance.total() - MINIMUM_STAKE_ACCOUNT_BALANCE)
             .expect("Stake account should always have the minimum amount.");
@@ -1681,12 +1678,12 @@ pub fn try_perform_maintenance(
         // as possible.
         .or_else(|| state.try_merge_on_all_stakes())
         .or_else(|| state.try_update_exchange_rate())
+        .or_else(|| state.try_withdraw_inactive_stake())
         .or_else(|| state.try_unstake_from_inactive_validator())
         // Collecting validator fees goes after updating the exchange rate,
         // because it may be rejected if the exchange rate is outdated.
         .or_else(|| state.try_collect_validator_fee())
         // Same for updating the validator balance.
-        .or_else(|| state.try_withdraw_inactive_stake())
         .or_else(|| state.try_stake_deposit())
         .or_else(|| state.try_unstake_from_active_validators())
         .or_else(|| state.try_claim_validator_fee())

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1013,7 +1013,7 @@ pub fn process_withdraw(
             stake_program: accounts.stake_program,
         },
         sol_to_withdraw,
-        &[&[]],
+        &[],
     )?;
 
     // Give control of the stake to the user.

--- a/program/src/stake_account.rs
+++ b/program/src/stake_account.rs
@@ -267,7 +267,10 @@ impl StakeAccount {
                 return true;
             }
             // Two activating accounts that share an activation epoch, during the activation epoch.
-            if self.is_activating() && merge_from.is_activating() {
+            if self.is_activating()
+                && merge_from.is_activating()
+                && self.activation_epoch == merge_from.activation_epoch
+            {
                 return true;
             }
         }


### PR DESCRIPTION
    correctly get inactive stake amount for withdraw and fix little issues that are reproduced locally

    When validator is deactivated effective stake balance is equal to
    stake balance so expected_difference_stake is 0. Thus inactive stake
    is not withdrawn by WithdrawInactiveStake following by Unstake instruction
    crash because the stake has more than rent exempt amount of inactive
    stake which is accumulated during previous stake merging.
    So first we withdraw inactive stake and then unstake.