### PR TITLE
Improved error handling, so that it doesn't crash when a maintainer account has an empty balance

### DIFF
--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -510,7 +510,6 @@ impl SolidoState {
             let account = match config.client.get_account(maintainer.pubkey()) {
                 Ok(account) => account,
                 Err(err) => {
-                    eprintln!("Failed to get account for maintainer: {:?}", maintainer.pubkey());
                     &empty_account
                 }
             };

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -506,9 +506,15 @@ impl SolidoState {
 
         let mut maintainer_balances = Vec::new();
         for maintainer in maintainers.entries.iter() {
-            maintainer_balances.push(Lamports(
-                config.client.get_account(maintainer.pubkey())?.lamports,
-            ));
+            let empty_account = Account::default();
+            let account = match config.client.get_account(maintainer.pubkey()) {
+                Ok(account) => account,
+                Err(err) => {
+                    eprintln!("Failed to get account for maintainer: {:?}", maintainer.pubkey());
+                    &empty_account
+                }
+            };
+            maintainer_balances.push(Lamports(account.lamports));
         }
 
         // The entity executing the maintenance transactions, is the maintainer.

--- a/cli/maintainer/src/maintenance.rs
+++ b/cli/maintainer/src/maintenance.rs
@@ -505,8 +505,8 @@ impl SolidoState {
         }
 
         let mut maintainer_balances = Vec::new();
+        let empty_account = Account::default();
         for maintainer in maintainers.entries.iter() {
-            let empty_account = Account::default();
             let account = match config.client.get_account(maintainer.pubkey()) {
                 Ok(account) => account,
                 Err(err) => {


### PR DESCRIPTION
Without this change, it's impossible to run the `perform-maintenance` command, that is required for withdrawals